### PR TITLE
Fix argument split when flag is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Allows you to specify the file name of the compressed report with the standard p
 #### Global parameters
 
 Allows you to create or override values for global parameters set in the test suite.
-Enter parameters according to the following pattern: "ParameterName=Value"
+Enter parameters according to the following pattern: "/pa:ParameterName=Value"
 Separate parameters with semicolons or newlines.
 
 #### Command line arguments

--- a/src/main/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameter.java
+++ b/src/main/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameter.java
@@ -9,6 +9,7 @@ public class RanorexParameter extends BaseArgument {
             "pa", "param"
     ));
     private static final String SEPARATOR = ":";
+    private static final String SLASH = "/";
 
 
     public RanorexParameter(String parameterString) {
@@ -41,8 +42,10 @@ public class RanorexParameter extends BaseArgument {
         if (containsValidNameValuePair(parameterString)) {
             int equalsPosition = parameterString.indexOf("=");
             int separatorPosition = parameterString.indexOf(SEPARATOR);
-            splitParam[1] = parameterString.substring(separatorPosition + 1, equalsPosition);
+            
+            splitParam[1] = IsStartingWithSlash(parameterString) ? parameterString.substring(separatorPosition + 1, equalsPosition) : parameterString.substring(0, equalsPosition);
             splitParam[2] = parameterString.substring(equalsPosition + 1, parameterString.length());
+            
         } else {
             throw new InvalidParameterException("Parameter is not valid");
         }
@@ -71,12 +74,18 @@ public class RanorexParameter extends BaseArgument {
 
     public static String tryExtractFlag(String parameterString) {
         int separatorPosition = parameterString.indexOf(SEPARATOR);
-        if (separatorPosition > 0) {
+        if (IsStartingWithSlash(parameterString) && separatorPosition > 0) {
             String flag = parameterString.substring(0, separatorPosition);
             flag = StringUtil.removeHeadingSlash(flag);
             return flag;
         } else {
             throw new InvalidParameterException("Parameter '" + parameterString + "' does not contain a separator!");
         }
+    }
+    
+    public static boolean IsStartingWithSlash(String parameterString)
+    {
+    	int slashPosition = parameterString.indexOf(SLASH);
+    	return slashPosition == 0;
     }
 }

--- a/src/test/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameterTest.java
+++ b/src/test/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameterTest.java
@@ -96,6 +96,14 @@ class RanorexParameterTest {
         assertEquals(valid.getName(), "TestName");
         assertEquals(valid.getValue(), "TestValue");
     }
+    
+    @Test
+    void Constructor_ValidInputStringWithoutPaWithColon_ValidRanorexParameter() {
+    	RanorexParameter valid = new RanorexParameter("TestName=http://test.com");
+    	assertEquals(valid.getFlag(), "pa");
+        assertEquals(valid.getName(), "TestName");
+        assertEquals(valid.getValue(), "http://test.com");
+    }
 
     @Test
     void Constructor_ValidInputStringParam_ValidRanorexParameter() {

--- a/src/test/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameterTest.java
+++ b/src/test/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameterTest.java
@@ -100,9 +100,9 @@ class RanorexParameterTest {
     @Test
     void Constructor_ValidInputStringWithoutPaWithColon_ValidRanorexParameter() {
         RanorexParameter valid = new RanorexParameter("TestName=http://test.com");
-        assertEquals(valid.getFlag(), "pa");
-        assertEquals(valid.getName(), "TestName");
-        assertEquals(valid.getValue(), "http://test.com");
+        assertEquals("pa",valid.getFlag());
+        assertEquals("TestName",valid.getName());
+        assertEquals("http://test.com",valid.getValue());
     }
 
     @Test

--- a/src/test/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameterTest.java
+++ b/src/test/java/com/ranorex/jenkinsranorexplugin/util/RanorexParameterTest.java
@@ -96,11 +96,11 @@ class RanorexParameterTest {
         assertEquals(valid.getName(), "TestName");
         assertEquals(valid.getValue(), "TestValue");
     }
-    
+
     @Test
     void Constructor_ValidInputStringWithoutPaWithColon_ValidRanorexParameter() {
-    	RanorexParameter valid = new RanorexParameter("TestName=http://test.com");
-    	assertEquals(valid.getFlag(), "pa");
+        RanorexParameter valid = new RanorexParameter("TestName=http://test.com");
+        assertEquals(valid.getFlag(), "pa");
         assertEquals(valid.getName(), "TestName");
         assertEquals(valid.getValue(), "http://test.com");
     }
@@ -134,12 +134,6 @@ class RanorexParameterTest {
     @Test
     void extractFlag_ValidInputWithSlash_ValidFlag() {
         String flag = RanorexParameter.tryExtractFlag("/param:Test=test");
-        assertEquals("param", flag);
-    }
-
-    @Test
-    void extractFlag_ValidInputWithoutSlash_ValidFlag() {
-        String flag = RanorexParameter.tryExtractFlag("param:Test=test");
         assertEquals("param", flag);
     }
 


### PR DESCRIPTION
Originally the colon is considered a separator, even in the case where flag is not provided and there is no separator (also as per documented usage of the field). 

Fix here preserves the (undocumented) ability to use /pa:ParamName=ParamValue, while ensuring that when it's not used, colon is not treated as separator.